### PR TITLE
use programattic project_name everywhere possible

### DIFF
--- a/nubis/builder/provisioners.json
+++ b/nubis/builder/provisioners.json
@@ -3,21 +3,21 @@
     {
       "type": "shell",
       "inline": [
-        "sudo mkdir -p -m 755 /var/www/dpaste",
-        "sudo chown ubuntu:ubuntu /var/www/dpaste"
+        "sudo mkdir -p -m 755 /var/www/{{user `project_name`}}",
+        "sudo chown ubuntu:ubuntu /var/www/{{user `project_name`}}"
       ],
       "order": "1"
     },
     {
       "type": "file",
       "source": "dpaste/",
-      "destination": "/var/www/dpaste",
+      "destination": "/var/www/{{user `project_name`}}",
       "order": "2"
     },
     {
       "type": "shell",
       "inline": [
-        "sudo python -m compileall /var/www/dpaste"
+        "sudo python -m compileall /var/www/{{user `project_name`}}"
       ],
       "order": "11"
     }

--- a/nubis/puppet/apache.pp
+++ b/nubis/puppet/apache.pp
@@ -4,10 +4,10 @@
 # [0] https://github.com/puppetlabs/puppetlabs-apache
 #
 
-$vhost_name = 'dpaste'
-$install_root = '/var/www/dpaste'
-$wsgi_path = '/var/www/dpaste/wsgi.py'
-$static_root = '/var/www/dpaste/dpaste/static/'
+$vhost_name = $project_name
+$install_root = "/var/www/${project_name}"
+$wsgi_path = "/var/www/${project_name}/wsgi.py"
+$static_root = "/var/www/${project_name}/dpaste/static/"
 $port = 80
 
 class { 'nubis_apache':

--- a/nubis/puppet/dpaste.pp
+++ b/nubis/puppet/dpaste.pp
@@ -18,19 +18,19 @@ file { '/usr/var':
 }
 
 # pip install requirements
-python::requirements { '/var/www/dpaste/requirements.txt':
+python::requirements { "/var/www/${project_name}/requirements.txt":
   require => [
     Class['python'],
     Class['mysql::bindings'],
   ]
 }
 
-file { '/var/www/dpaste/wsgi.py':
+file { "/var/www/${project_name}/wsgi.py":
   ensure => present,
   source => 'puppet:///nubis/files/wsgi.py',
 }
 
-file { '/var/www/dpaste/dpaste/settings/local.py':
+file { "/var/www/${project_name}/dpaste/settings/local.py":
   ensure => present,
   source => 'puppet:///nubis/files/local.py',
 }
@@ -39,7 +39,7 @@ file { '/var/www/dpaste/dpaste/settings/local.py':
 
 include nubis_configuration
 
-file { '/usr/local/bin/dpaste-update':
+file { "/usr/local/bin/${project_name}-update":
   ensure => present,
   source => 'puppet:///nubis/files/update',
   owner  => root,
@@ -47,7 +47,7 @@ file { '/usr/local/bin/dpaste-update':
   mode   => '0755',
 }
 
-nubis::configuration{ 'dpaste':
+nubis::configuration{ $project_name:
   format => 'sh',
-  reload => '/usr/local/bin/dpaste-update'
+  reload => "/usr/local/bin/${project_name}-update"
 }


### PR DESCRIPTION
Makes for a better example, especially:
```
{{user `project_name`}}
```
in provisionners.json

Fixes #130